### PR TITLE
fix: reauth when token expire due to inactivity

### DIFF
--- a/src/DilaApiClient.ts
+++ b/src/DilaApiClient.ts
@@ -52,7 +52,13 @@ export class DilaApiClient {
         "content-type": "application/json"
       },
       method
-    }).then(r => r.json());
+    }).then(r => {
+      if (r.status === 401 && this.globalToken) {
+        this.globalToken = undefined;
+        return this.fetch({ path, method, params });
+      }
+      return r.json();
+    });
 
     if (data.error) {
       throw new Error(`Error on API fetch: ${JSON.stringify(data)}`);


### PR DESCRIPTION
Bonjour à tous, j'ai d'abord tester mon code dans une api en modifiant le code JS compilé directement et pas de soucis le fix marche bien mais n'étant pas aficionado du TS je me retrouve avec deux erreurs que je n'avais pas en JS a savoir.

```
src/DilaApiClient.ts:33:16 - error TS7023: 'fetch' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.

33   public async fetch({
                  ~~~~~

src/DilaApiClient.ts:48:11 - error TS7022: 'data' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.

48     const data = await fetch(url, {
```
De plus, j'ai modifié aussi au niveau de this.globalToken = undefined de base dans mon JS qui marchait, j'avais mis null mais vu qu'il y avait un soucis de type avec null et String je pense que le undefined a plus ca place en TS

Si vous avez des idées je suis preneur. 

Merci par avance